### PR TITLE
Some description in gemspec to make it valid

### DIFF
--- a/suwabara.gemspec
+++ b/suwabara.gemspec
@@ -3,8 +3,8 @@ Gem::Specification.new do |spec|
   spec.version       = '0.0.1'
   spec.authors       = ['Peter Zotov']
   spec.email         = ['whitequark@whitequark.org']
-  spec.description   = %q{TODO: Write a gem description}
-  spec.summary       = %q{TODO: Write a gem summary}
+  spec.description   = %q{Asset storage engine}
+  spec.summary       = %q{Asset storage engine}
   spec.homepage      = 'http://github.com/whitequark/suwabara'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
Otherwise:

```
Using suwabara (0.0.1) from git://github.com/whitequark/suwabara.git (at master)
suwabara did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  "FIXME" or "TODO" is not a description
```
