### PR TITLE
Get duration when it is possible

### DIFF
--- a/lib/suwabara/stored_audio.rb
+++ b/lib/suwabara/stored_audio.rb
@@ -6,8 +6,10 @@ module Suwabara
     def initialize_from_io(io, original_name)
       super
 
-      movie = FFMPEG::Movie.new(full_path.to_s)
-      @duration = movie.duration
+      if io.respond_to?(:path)
+        movie = FFMPEG::Movie.new(io.path)
+        @duration = movie.duration
+      end
     end
 
     def initialize_from_hash(hash)


### PR DESCRIPTION
full_path method works different now and for new instances without id this method will raise exception
