### PR TITLE
You don't want to write files when the record is destroyed

### DIFF
--- a/lib/suwabara/orm/activerecord.rb
+++ b/lib/suwabara/orm/activerecord.rb
@@ -6,7 +6,7 @@ module Suwabara::ORM
     attr_reader :_suwabara_files
 
     included do
-      after_commit :write_files
+      after_commit :write_files, on: [:create, :update]
     end
 
     def write_files


### PR DESCRIPTION
And even if you want (for what reason?), it won't work. Because when destroyed, `self.storage` would call `self.storage_for(name)`, and `name` might be `nil` already.
