### PR TITLE
Use mimemagic to detect filetype if the file has no extension

### DIFF
--- a/lib/suwabara/stored_file.rb
+++ b/lib/suwabara/stored_file.rb
@@ -1,3 +1,5 @@
+require 'mimemagic'
+
 module Suwabara
   class StoredFile
     attr_reader :name, :size
@@ -44,7 +46,11 @@ module Suwabara
     private :initialize_from_io, :initialize_from_hash
 
     def content_type
-      MIME::Types.of(File.extname(@name)).first.content_type
+      if File.extname(@name)
+        MIME::Types.of(File.extname(@name)).first.content_type
+      else
+        MimeMagic.by_magic(File.open(self.full_path)).to_s
+      end
     end
 
     def read

--- a/suwabara.gemspec
+++ b/suwabara.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9'
 
   spec.add_dependency 'mime-types',      '~> 1.20'
+  spec.add_dependency 'mimemagic',       '~> 0.2.1'
   spec.add_dependency 'mini_magick',     '~> 3.5'
   spec.add_dependency 'streamio-ffmpeg', '~> 0.9.0'
 


### PR DESCRIPTION
Not sure if this is GTM. 
1. rake fails with 3 errors, not related to this change. 
2. Should I require mimemagic explicitly if it's already in gemfile? Just to be sure. 

What do you think? 
